### PR TITLE
Fix kerf

### DIFF
--- a/quickjoint.inx
+++ b/quickjoint.inx
@@ -26,7 +26,8 @@
         <item value="in">in</item>
         <item value="cm">cm</item>
     </param>
-    <param name="edgefeatures" type="boolean" _gui-text="Features on edges">False</param>
+    <param name="featureStart" type="boolean" _gui-text="Feature at start">False</param>
+    <param name="featureEnd" type="boolean" _gui-text="Feature at end">False</param>
     <param name="flipside" type="boolean" _gui-text="Flip side">False</param>
     <effect needs-live-preview="true">
         <object-type>path</object-type>

--- a/quickjoint.inx
+++ b/quickjoint.inx
@@ -28,7 +28,6 @@
     </param>
     <param name="edgefeatures" type="boolean" _gui-text="Features on edges">False</param>
     <param name="flipside" type="boolean" _gui-text="Flip side">False</param>
-    <param name="insetkerf" type="boolean" _gui-text="Inset kerf">True</param>
     <effect needs-live-preview="true">
         <object-type>path</object-type>
         <effects-menu>

--- a/quickjoint.inx
+++ b/quickjoint.inx
@@ -28,6 +28,7 @@
     </param>
     <param name="edgefeatures" type="boolean" _gui-text="Features on edges">False</param>
     <param name="flipside" type="boolean" _gui-text="Flip side">False</param>
+    <param name="insetkerf" type="boolean" _gui-text="Inset kerf">True</param>
     <effect needs-live-preview="true">
         <object-type>path</object-type>
         <effects-menu>

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -62,10 +62,6 @@ class QuickJoint(inkex.Effect):
        
         return complex(line[0], line[1]) 
         
-    def get_length(self, line):
-        polR, polPhi = cmath.polar(line)
-        return polR
-        
     def draw_parallel(self, start, guideLine, stepDistance):
         polR, polPhi = cmath.polar(guideLine)
         polR = stepDistance

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -88,38 +88,33 @@ class QuickJoint(inkex.Effect):
         lines.append(['L', [point.real, point.imag]])
         
     def draw_box(self, start, lengthVector, height, kerf):
-        length, lengthDirection = cmath.polar(lengthVector)
-        heightDirection = lengthDirection - (cmath.pi / 2)
-        if self.flipside: heightDirection = -heightDirection
 
-        debugMsg("draw_box; lengthVector: " + str(lengthVector) + ", kerf: " + str(kerf))
-        
-        cursor = start
         # Kerf is a provided as a positive kerf width. Although tabs
         # need to be made larger by the width of the kerf, slots need
-        # to be made narrower instead, since the kerf widens them.
-        kerf = -kerf
+        # to be made narrower instead, since the cut widens them.
+
+        # Calculate kerfed height and length vectors
+        heightEdge = self.draw_perpendicular(0, lengthVector, height - kerf, self.flipside)
+        lengthEdge = self.draw_parallel(lengthVector, lengthVector, -kerf)
         
-        cursor -= cmath.rect(kerf/2, lengthDirection)
-        cursor -= cmath.rect(kerf/2, heightDirection)
+        debugMsg("draw_box; lengthEdge: " + str(lengthEdge) + ", heightEdge: " + str(heightEdge))
+        
+        cursor = self.draw_parallel(start, lengthEdge, kerf/2)
+        cursor = self.draw_perpendicular(cursor, heightEdge, kerf/2)
         
         lines = []
         self.move(lines, cursor)
         
-        # Slot length
-        cursor += cmath.rect(length + kerf, lengthDirection)
+        cursor += lengthEdge
         self.line(lines, cursor)
         
-        # Slot height
-        cursor += cmath.rect(height  + kerf, heightDirection)
+        cursor += heightEdge
         self.line(lines, cursor)
         
-        # Back slot length
-        cursor += cmath.rect(length + kerf, lengthDirection + cmath.pi)
+        cursor -= lengthEdge
         self.line(lines, cursor)
 
-        # Back Slot height
-        cursor += cmath.rect(height  + kerf, heightDirection + cmath.pi)
+        cursor -= heightEdge
         self.line(lines, cursor)
         
         lines.append(['Z', []])
@@ -128,7 +123,7 @@ class QuickJoint(inkex.Effect):
 
     def vectorDraw(self, start, lines, vector):
         start = start + vector
-        lines.append(['L', [start.real, start.imag]])
+        self.draw(lines, start)
         return start
 
     def draw_tabs(self, path, line):

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -26,7 +26,7 @@ import inkex, cmath
 from inkex.paths import Path, ZoneClose, Move
 from lxml import etree
     
-debugEn = True
+debugEn = False
 def debugMsg(input):
     if debugEn:
         inkex.utils.debug(input)

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -55,6 +55,7 @@ class QuickJoint(inkex.Effect):
         pars.add_argument('-e', '--edgefeatures', type=inkex.Boolean, default=False, help='Allow tabs to go right to edges')
         pars.add_argument('-f', '--flipside', type=inkex.Boolean, default=False, help='Flip side of lines that tabs are drawn onto')
         pars.add_argument('-a', '--activetab', default='', help='Tab or slot menus')
+        pars.add_argument('-i', '--insetkerf', type=inkex.Boolean, default=True, help='Kerf contracts tabs and slots instead of expanding them')
                         
     def to_complex(self, command, line):
         debugMsg('To complex: ' + command + ' ' + str(line))
@@ -169,7 +170,7 @@ class QuickJoint(inkex.Effect):
         debugMsg('segLength - ' + str(segLength))
         newLines = []
         
-        # when handling firlt line need to set M back
+        # when handling first line need to set M back
         if isinstance(path[line], Move):
             newLines.append(['M', [start.real, start.imag]])
 
@@ -266,7 +267,12 @@ class QuickJoint(inkex.Effect):
         self.edgefeatures = self.options.edgefeatures
         self.flipside = self.options.flipside
         self.activetab = self.options.activetab
-        
+        self.insetkerf = self.options.insetkerf
+
+        # Should kerf expand or contract slot size? inset = slot is contracted; kerf is subtracted from box
+        if self.insetkerf:
+            self.kerf = self.kerf * -1
+            
         for id, node in self.svg.selected.items():
             debugMsg(node)
             debugMsg('1')

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -61,15 +61,16 @@ class QuickJointPath (Path):
 
     def get_line(self, n):
         '''Return the end points of the nth line in the path as complex numbers, as well as whether that line closes the path.'''
-        start = complex(self[n].real, self[n].imag)
+
+        start = complex(self[n].x, self[n].y)
         # If the next point in the path closes the path, go back to the start.
         end = None
         closePath = False
         if isinstance(self[n+1], ZoneClose):
-            end = complex(self[0].real, self[0].imag)
+            end = complex(self[0].x, self[0].y)
             closePath = True
         else:
-            end = complex(self[n+1].real, self[n+1].imag)
+            end = complex(self[n+1].x, self[n+1].y)
         return (start, end, closePath)
 
 class QuickJoint(inkex.Effect):

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -147,26 +147,23 @@ class QuickJoint(inkex.Effect):
    
         debugMsg('5-')
 
-        if self.edgefeatures:
-            segCount = (self.numtabs * 2) - 1
-            drawValley = False
-        else:
-            segCount = (self.numtabs * 2)
-            drawValley = False
-          
         distance = end - start
-        debugMsg('distance ' + str(distance))
-        debugMsg('segCount ' + str(segCount))
-        
+
         try:
             if self.edgefeatures:
+                segCount = (self.numtabs * 2) - 1
                 segLength = self.get_length(distance) / segCount
             else:
+                segCount = (self.numtabs * 2)
                 segLength = self.get_length(distance) / (segCount + 1)
         except:
-            debugMsg('in except')
+            debugMsg('Exception calculating SegLength')
             segLength = self.get_length(distance)
-        
+
+        drawValley = False
+          
+        debugMsg('distance ' + str(distance))
+        debugMsg('segCount ' + str(segCount))
         debugMsg('segLength - ' + str(segLength))
         newLines = []
         

--- a/quickjoint.py
+++ b/quickjoint.py
@@ -153,7 +153,7 @@ class QuickJoint(inkex.Effect):
         else:
             end = to_complex(path[line+1])
 
-        debugMsg('start: ' + str(start) + "; snd: " + str(end))
+        debugMsg('start: ' + str(start) + "; end: " + str(end))
 
         distance = end - start
 


### PR DESCRIPTION
This patch set fixes several problems with QuickJoint's handling of kerfs, and adds the ability to toggle features on the start and end of the line separately.
- Fixed kerf compensation for Slots. In slots, the laser kerf expands the size of the slot, so the kerf compensation must contract the slot instead of expanding it.
- Added support for kerf compensation in Tabs. I did a bit of a rewrite as a part of this, over a few rounds of changes.
  - Kerf compensation is required only along the length of the tab, not in its height, since the kerf affects parallel lines in the same way
  - I notionally separated the line into Tabs and Spaces (where there is no tab), and calculated the kerf-compensated width of each tab and space, depending on whether it is on the end or not.
- Added support for toggling features on each end separately. This allows for use of the same part on all four sides of a box, or to place tabs more effectively in some other situations.

I have visually tested this extensively, and have just cut the first few parts designed using the new patches. I am happy with the way things have turned out.

I'm a newb python programmer, so I feel like there's a better way to do some of these things, but this works and it exists.

Thanks for your work on this extension! I like the flexibility of QuickJoint better than the "build a whole box" extensions, but I like this even better with a few more features.

 